### PR TITLE
fix installations badge url

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 
 image:https://ci.jenkins.io/job/Plugins/job/custom-folder-icon-plugin/job/master/badge/icon[link="https://ci.jenkins.io/job/Plugins/job/custom-folder-icon-plugin/job/master/"]
 image:https://img.shields.io/github/contributors/jenkinsci/custom-folder-icon-plugin.svg?color=blue[link="https://github.com/jenkinsci/custom-folder-icon-plugin/graphs/contributors"]
-image:https://img.shields.io/jenkins/plugin/i/custom-folder-icon-plugin.svg?color=blue&label=installations[link="https://plugins.jenkins.io/custom-folder-icon-plugin"]
+image:https://img.shields.io/jenkins/plugin/i/custom-folder-icon.svg?color=blue&label=installations[link="https://plugins.jenkins.io/custom-folder-icon"]
 image:https://img.shields.io/github/release/jenkinsci/custom-folder-icon-plugin.svg?label=changelog[link="https://github.com/jenkinsci/custom-folder-icon-plugin/releases/latest"]
 
 [#introduction]


### PR DESCRIPTION
Despite the indication of the preview this should be the correct link (all plugins hosted under *plugins.jenkins.io* omit the `-plugin` ending AFAIK)

If you want I can throw a Dependabot and Release Drafter config into this or another PR :wink: 