### PR TITLE
Infra: Add Release Drafter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+# Extends the default ReleaseDrafter config provided in https://github.com/jenkinsci/.github
+_extends: .github
+tag-template: custom-folder-icon-$NEXT_MINOR_VERSION
+name-template: Custom Folder Icon v$NEXT_MINOR_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+# Automates creation of Release Drafts using Release Drafter
+# More Info: https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5.11.0
+        with:
+          # Publishes a new GH Release automatically once a tag gets pushed
+          publish: startsWith(github.ref, "refs/tags")
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds Release Drafter to this repository.
Also adds GH Action to Dependabot config, so that the RD action can never get outdated. (only on a weekly interval as GH Actions don't update too often )

If you have questions to Release Drafter have a read in [jenkinsci/.github/release-drafter.adoc](https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc) or the normal [Release Drafter Docu](https://github.com/release-drafter/release-drafter)

(sorry I simply like doing Infra PRs :confused: )

/edit: The config for the Release Drafter Action is set up to auto publish a new GH Release once a new Tag gets pushed to the repository (whilst using the til then drafted release change notes), just FYI