### PR TITLE
Drop dependency on Commons Lang 3

### DIFF
--- a/src/test/java/jenkins/plugins/foldericon/BuildStatusFolderIconTest.java
+++ b/src/test/java/jenkins/plugins/foldericon/BuildStatusFolderIconTest.java
@@ -32,7 +32,7 @@ import jenkins.plugins.foldericon.BuildStatusFolderIcon.DescriptorImpl;
 import jenkins.plugins.foldericon.utils.DelayBuilder;
 import jenkins.plugins.foldericon.utils.ResultPublisher;
 import jenkins.plugins.foldericon.utils.TestUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;

--- a/src/test/java/jenkins/plugins/foldericon/EmojiFolderIconTest.java
+++ b/src/test/java/jenkins/plugins/foldericon/EmojiFolderIconTest.java
@@ -28,7 +28,7 @@ import com.cloudbees.hudson.plugins.folder.Folder;
 import com.cloudbees.hudson.plugins.folder.FolderIcon;
 import jenkins.branch.OrganizationFolder;
 import jenkins.plugins.foldericon.EmojiFolderIcon.DescriptorImpl;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;

--- a/src/test/java/jenkins/plugins/foldericon/IoniconFolderIconTest.java
+++ b/src/test/java/jenkins/plugins/foldericon/IoniconFolderIconTest.java
@@ -29,7 +29,7 @@ import com.cloudbees.hudson.plugins.folder.FolderIcon;
 import io.jenkins.plugins.ionicons.Ionicons;
 import jenkins.branch.OrganizationFolder;
 import jenkins.plugins.foldericon.IoniconFolderIcon.DescriptorImpl;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;

--- a/src/test/java/jenkins/plugins/foldericon/utils/MockMultiPartRequest.java
+++ b/src/test/java/jenkins/plugins/foldericon/utils/MockMultiPartRequest.java
@@ -27,7 +27,7 @@ package jenkins.plugins.foldericon.utils;
 import net.sf.json.JSONObject;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemHeaders;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.bind.BoundObjectTable;
 import org.kohsuke.stapler.lang.Klass;

--- a/src/test/java/jenkins/plugins/foldericon/utils/TestUtils.java
+++ b/src/test/java/jenkins/plugins/foldericon/utils/TestUtils.java
@@ -26,7 +26,7 @@ package jenkins.plugins.foldericon.utils;
 
 import com.cloudbees.hudson.plugins.folder.FolderIcon;
 import jenkins.plugins.foldericon.Emojis;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins-test-harness/issues/550. Commons Lang 3 is only exposed to tests by accident, which I intend to fix soon by shading this library. Its accidental presence leads to undefined behavior if someone actually depends on the Commons Lang 3 API plugin (basically whichever one happens to be first on the classpath will win). I plan to fix all of this soon, but before I can do that, this plugin needs to stop relying on this implementation detail of the current test harness.

There are two ways to deal with this: either depend on Commons Lang 2.x instead (which is shipped as part of Jenkins core), or add an explicit (test-scoped) dependency on the Commons Lang 3 API Jenkins plugin.

For this PR I opted to do the first approach, since it didn't seem like this plugin cared enough about which version of `StringUtils` was being used.

### Testing done

`mvn clean verify` against a development copy of the test harness with Commons Lang 3 shaded

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
