### PR TITLE
Allow users with Overall/Manage permission to interact with global configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
     <revision>2.13</revision>
     <changelist>-SNAPSHOT</changelist>
     <spotless.check.skip>false</spotless.check.skip>
+    <!-- needed for Jenkins.MANAGE support -->
+    <useBeta>true</useBeta>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/jenkins/plugins/foldericon/CustomFolderIconConfiguration.java
+++ b/src/main/java/jenkins/plugins/foldericon/CustomFolderIconConfiguration.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.PageDecorator;
+import hudson.security.Permission;
 import java.io.IOException;
 import java.util.Set;
 import java.util.logging.Level;
@@ -63,15 +64,20 @@ public class CustomFolderIconConfiguration extends PageDecorator {
         return GlobalConfigurationCategory.get(AppearanceCategory.class);
     }
 
+    @NonNull
+    @Override
+    public Permission getRequiredGlobalConfigPagePermission() {
+        return Jenkins.MANAGE;
+    }
+
     /**
      * Get human-readable disk-usage of all icons.
      *
-     * @return OK
+     * @return human-readable disk-usage
      */
-    @SuppressWarnings("unused")
     @NonNull
     public String getDiskUsage() {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
 
         FilePath iconDir = Jenkins.get().getRootPath().child(USER_CONTENT_PATH).child(PLUGIN_PATH);
 
@@ -97,7 +103,7 @@ public class CustomFolderIconConfiguration extends PageDecorator {
      */
     @RequirePOST
     public HttpResponse doCleanup(@SuppressWarnings("unused") StaplerRequest req) {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
 
         FilePath iconDir = Jenkins.get().getRootPath().child(USER_CONTENT_PATH).child(PLUGIN_PATH);
 

--- a/src/test/java/jenkins/plugins/foldericon/CustomFolderIconConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/foldericon/CustomFolderIconConfigurationTest.java
@@ -39,6 +39,7 @@ import javax.servlet.http.HttpServletResponse;
 import jenkins.appearance.AppearanceCategory;
 import jenkins.branch.OrganizationFolder;
 import jenkins.model.GlobalConfigurationCategory;
+import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;
@@ -69,6 +70,15 @@ class CustomFolderIconConfigurationTest {
     void testGetCategory(@SuppressWarnings("unused") JenkinsRule r) {
         CustomFolderIconConfiguration descriptor = new CustomFolderIconConfiguration();
         assertEquals(descriptor.getCategory(), GlobalConfigurationCategory.get(AppearanceCategory.class));
+    }
+
+    /**
+     * Test behavior of {@link CustomFolderIconConfiguration#getRequiredGlobalConfigPagePermission()}.
+     */
+    @Test
+    void testGetRequiredGlobalConfigPagePermission(@SuppressWarnings("unused") JenkinsRule r) {
+        CustomFolderIconConfiguration descriptor = new CustomFolderIconConfiguration();
+        assertEquals(Jenkins.MANAGE, descriptor.getRequiredGlobalConfigPagePermission());
     }
 
     /**

--- a/src/test/java/jenkins/plugins/foldericon/JobDSLConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/foldericon/JobDSLConfigurationTest.java
@@ -50,6 +50,11 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 @WithJenkins
 class JobDSLConfigurationTest {
 
+    /**
+     * Test behavior for build-status.groovy.
+     *
+     * @throws Exception in case anything goes wrong
+     */
     @Test
     void testBuildStatusFolderIcon(JenkinsRule r) throws Exception {
         BuildStatusFolderIcon customIcon = createFolder(r, "build-status.groovy", BuildStatusFolderIcon.class);
@@ -57,6 +62,11 @@ class JobDSLConfigurationTest {
         assertEquals(BallColor.NOTBUILT.getIconClassName(), customIcon.getIconClassName());
     }
 
+    /**
+     * Test behavior for build-status.groovy.
+     *
+     * @throws Exception in case anything goes wrong
+     */
     @Test
     void testCustomIconFolderIcon(JenkinsRule r) throws Exception {
         CustomFolderIcon customIcon = createFolder(r, "custom-icon.groovy", CustomFolderIcon.class);
@@ -64,18 +74,33 @@ class JobDSLConfigurationTest {
         assertEquals(Set.of("custom.png"), CustomFolderIcon.getAvailableIcons());
     }
 
+    /**
+     * Test behavior for emoji-icon.groovy.
+     *
+     * @throws Exception in case anything goes wrong
+     */
     @Test
     void testEmojiFolderIcon(JenkinsRule r) throws Exception {
         EmojiFolderIcon customIcon = createFolder(r, "emoji-icon.groovy", EmojiFolderIcon.class);
         assertEquals("sloth", customIcon.getEmoji());
     }
 
+    /**
+     * Test behavior for fontawesome-icon.groovy.
+     *
+     * @throws Exception in case anything goes wrong
+     */
     @Test
     void testFontAwesomeFolderIcon(JenkinsRule r) throws Exception {
         FontAwesomeFolderIcon customIcon = createFolder(r, "fontawesome-icon.groovy", FontAwesomeFolderIcon.class);
         assertEquals("brands/jenkins", customIcon.getFontAwesome());
     }
 
+    /**
+     * Test behavior for ionicon-icon.groovy.
+     *
+     * @throws Exception in case anything goes wrong
+     */
     @Test
     void testIoniconFolderIcon(JenkinsRule r) throws Exception {
         IoniconFolderIcon customIcon = createFolder(r, "ionicon-icon.groovy", IoniconFolderIcon.class);

--- a/src/test/java/jenkins/plugins/foldericon/PermissionTest.java
+++ b/src/test/java/jenkins/plugins/foldericon/PermissionTest.java
@@ -188,8 +188,7 @@ class PermissionTest {
     }
 
     /**
-     * Test behavior of {@link CustomFolderIconConfiguration#getDiskUsage()} (StaplerRequest)}.
-     *
+     * Test behavior of {@link CustomFolderIconConfiguration#getDiskUsage()}.
      */
     @Test
     void testGetDiskUsage(JenkinsRule r) {

--- a/src/test/java/jenkins/plugins/foldericon/PermissionTest.java
+++ b/src/test/java/jenkins/plugins/foldericon/PermissionTest.java
@@ -40,6 +40,7 @@ import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
 import jenkins.plugins.foldericon.CustomFolderIcon.DescriptorImpl;
 import jenkins.plugins.foldericon.utils.MockMultiPartRequest;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
@@ -56,7 +57,9 @@ import org.springframework.security.access.AccessDeniedException;
 @WithJenkins
 class PermissionTest {
 
-    private static final String ADMIN_USER = "administering_sloth";
+    private static final String ADMINISTRATOR_USER = "administering_sloth";
+
+    private static final String MANAGE_USER = "managing_axolotl";
 
     private static final String CONFIGURE_USER = "configuring_red_panda";
 
@@ -83,7 +86,8 @@ class PermissionTest {
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
 
         MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
-        strategy.grant(Jenkins.ADMINISTER).onItems(project).to(ADMIN_USER);
+        strategy.grant(Jenkins.ADMINISTER).onItems(project).to(ADMINISTRATOR_USER);
+        strategy.grant(Jenkins.MANAGE).onItems(project).to(MANAGE_USER);
         strategy.grant(Item.CONFIGURE).onItems(project).to(CONFIGURE_USER);
         strategy.grant(Item.READ).onItems(project).to(READ_USER);
         r.jenkins.setAuthorizationStrategy(strategy);
@@ -96,6 +100,9 @@ class PermissionTest {
         try (ACLContext ignored = ACL.as(User.get(READ_USER, true, Collections.emptyMap()))) {
             assertThrows(AccessDeniedException.class, () -> descriptor.doUploadIcon(mockRequest, null));
             assertThrows(AccessDeniedException.class, () -> descriptor.doUploadIcon(mockRequest, project));
+
+            strategy.grant(Jenkins.READ).onRoot().to(READ_USER);
+            assertThrows(AccessDeniedException.class, () -> descriptor.doUploadIcon(mockRequest, project));
         }
 
         // Item.CONFIGURE
@@ -106,14 +113,23 @@ class PermissionTest {
             validateResponse(response, 0, FILE_NAME_PATTERN, null);
         }
 
+        // Jenkins.MANAGE
+        try (ACLContext ignored = ACL.as(User.get(MANAGE_USER, true, Collections.emptyMap()))) {
+            assertThrows(AccessDeniedException.class, () -> descriptor.doUploadIcon(mockRequest, null));
+            assertThrows(AccessDeniedException.class, () -> descriptor.doUploadIcon(mockRequest, project));
+
+            strategy.grant(Jenkins.MANAGE).onRoot().to(MANAGE_USER);
+            assertThrows(AccessDeniedException.class, () -> descriptor.doUploadIcon(mockRequest, project));
+        }
+
         // Jenkins.ADMINISTER
-        try (ACLContext ignored = ACL.as(User.get(ADMIN_USER, true, Collections.emptyMap()))) {
+        try (ACLContext ignored = ACL.as(User.get(ADMINISTRATOR_USER, true, Collections.emptyMap()))) {
             assertThrows(AccessDeniedException.class, () -> descriptor.doUploadIcon(mockRequest, null));
 
             HttpResponse response = descriptor.doUploadIcon(mockRequest, project);
             validateResponse(response, 0, FILE_NAME_PATTERN, null);
 
-            strategy.grant(Jenkins.ADMINISTER).onRoot().to(ADMIN_USER);
+            strategy.grant(Jenkins.ADMINISTER).onRoot().to(ADMINISTRATOR_USER);
             response = descriptor.doUploadIcon(mockRequest, project);
             validateResponse(response, 0, FILE_NAME_PATTERN, null);
         }
@@ -141,8 +157,8 @@ class PermissionTest {
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
 
         MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
-        strategy.grant(Jenkins.ADMINISTER).onRoot().to(ADMIN_USER);
-        strategy.grant(Jenkins.MANAGE).onRoot().to(CONFIGURE_USER);
+        strategy.grant(Jenkins.ADMINISTER).onRoot().to(ADMINISTRATOR_USER);
+        strategy.grant(Jenkins.MANAGE).onRoot().to(MANAGE_USER);
         strategy.grant(Jenkins.READ).onRoot().to(READ_USER);
         r.jenkins.setAuthorizationStrategy(strategy);
 
@@ -157,16 +173,54 @@ class PermissionTest {
         }
 
         // Jenkins.MANAGE
-        try (ACLContext ignored = ACL.as(User.get(CONFIGURE_USER, true, Collections.emptyMap()))) {
-            assertThrows(AccessDeniedException.class, () -> descriptor.doCleanup(null));
-            assertTrue(file.exists());
-        }
-
-        // Jenkins.ADMINISTER
-        try (ACLContext ignored = ACL.as(User.get(ADMIN_USER, true, Collections.emptyMap()))) {
+        try (ACLContext ignored = ACL.as(User.get(MANAGE_USER, true, Collections.emptyMap()))) {
             HttpResponse response = descriptor.doCleanup(null);
             validateResponse(response, HttpServletResponse.SC_OK, null, null);
             assertFalse(file.exists());
+        }
+
+        // Jenkins.ADMINISTER
+        try (ACLContext ignored = ACL.as(User.get(ADMINISTRATOR_USER, true, Collections.emptyMap()))) {
+            HttpResponse response = descriptor.doCleanup(null);
+            validateResponse(response, HttpServletResponse.SC_OK, null, null);
+            assertFalse(file.exists());
+        }
+    }
+
+    /**
+     * Test behavior of {@link CustomFolderIconConfiguration#getDiskUsage()} (StaplerRequest)}.
+     *
+     */
+    @Test
+    void testGetDiskUsage(JenkinsRule r) {
+        CustomFolderIconConfiguration descriptor = new CustomFolderIconConfiguration();
+
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+
+        MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
+        strategy.grant(Jenkins.ADMINISTER).onRoot().to(ADMINISTRATOR_USER);
+        strategy.grant(Jenkins.MANAGE).onRoot().to(MANAGE_USER);
+        strategy.grant(Jenkins.READ).onRoot().to(READ_USER);
+        r.jenkins.setAuthorizationStrategy(strategy);
+
+        // unauthenticated
+        assertThrows(AccessDeniedException.class, descriptor::getDiskUsage);
+
+        // Jenkins.READ
+        try (ACLContext ignored = ACL.as(User.get(READ_USER, true, Collections.emptyMap()))) {
+            assertThrows(AccessDeniedException.class, descriptor::getDiskUsage);
+        }
+
+        // Jenkins.MANAGE
+        try (ACLContext ignored = ACL.as(User.get(MANAGE_USER, true, Collections.emptyMap()))) {
+            String size = descriptor.getDiskUsage();
+            assertEquals(FileUtils.byteCountToDisplaySize(0), size);
+        }
+
+        // Jenkins.ADMINISTER
+        try (ACLContext ignored = ACL.as(User.get(ADMINISTRATOR_USER, true, Collections.emptyMap()))) {
+            String size = descriptor.getDiskUsage();
+            assertEquals(FileUtils.byteCountToDisplaySize(0), size);
         }
     }
 }

--- a/svg-generator.ps1
+++ b/svg-generator.ps1
@@ -43,7 +43,7 @@ $SVGTemplate = "<svg xmlns=`"http://www.w3.org/2000/svg`" class=`"emoji`" viewBo
 
 $counter = 0
 
-$performance = Measure-Command {
+$runtime = Measure-Command {
     foreach ($line in Get-Content -Encoding UTF8 $EmojiList)
     {
         $splitLine = $line.Split(":")
@@ -60,4 +60,4 @@ $performance = Measure-Command {
     }
 }
 
-"Done. Created " + $counter + " SVGs in " + $performance.Milliseconds + " ms" | Out-Host
+"Done. Created " + $counter + " SVGs in " + $runtime.Milliseconds + " ms" | Out-Host


### PR DESCRIPTION
Inspired by https://github.com/jenkinsci/cloudbees-folder-plugin/pull/395

Allow users with Overall/Manage permission to interact with global configuration.

### Testing done

Tests added and adapted accordingly.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```