### PR TITLE
Return symbol for buildstatus icon

### DIFF
--- a/src/main/java/jenkins/plugins/foldericon/BuildStatusFolderIcon.java
+++ b/src/main/java/jenkins/plugins/foldericon/BuildStatusFolderIcon.java
@@ -119,7 +119,7 @@ public class BuildStatusFolderIcon extends FolderIcon {
 
     @Override
     public String getIconClassName() {
-        return getCombinedBallColor().getIconClassName();
+        return "symbol-status-" + getCombinedBallColor().getIconName();
     }
 
     @Override

--- a/src/test/java/jenkins/plugins/foldericon/BuildStatusFolderIconTest.java
+++ b/src/test/java/jenkins/plugins/foldericon/BuildStatusFolderIconTest.java
@@ -1,7 +1,7 @@
 package jenkins.plugins.foldericon;
 
 import static jenkins.plugins.foldericon.utils.TestUtils.mockStaplerRequest;
-import static jenkins.plugins.foldericon.utils.TestUtils.validateIcon;
+import static jenkins.plugins.foldericon.utils.TestUtils.validateSymbol;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mockStatic;
 
@@ -90,32 +90,32 @@ class BuildStatusFolderIconTest {
             BuildStatusFolderIcon customIcon = new BuildStatusFolderIcon(Set.of());
             project.setIcon(customIcon);
             FolderIcon icon = project.getIcon();
-            validateIcon(icon, BallColor.ABORTED.getImage(), BallColor.ABORTED.getIconClassName());
+            validateSymbol(icon, BallColor.ABORTED.getImage(), BallColor.ABORTED.getIconName());
 
             customIcon = new BuildStatusFolderIcon(Set.of("Success"));
             project.setIcon(customIcon);
             icon = project.getIcon();
-            validateIcon(icon, BallColor.BLUE.getImage(), BallColor.BLUE.getIconClassName());
+            validateSymbol(icon, BallColor.BLUE.getImage(), BallColor.BLUE.getIconName());
 
             customIcon = new BuildStatusFolderIcon(Set.of("Success", "Aborted"));
             project.setIcon(customIcon);
             icon = project.getIcon();
-            validateIcon(icon, BallColor.ABORTED.getImage(), BallColor.ABORTED.getIconClassName());
+            validateSymbol(icon, BallColor.ABORTED.getImage(), BallColor.ABORTED.getIconName());
 
             customIcon = new BuildStatusFolderIcon(Set.of("subfolder » Nested"));
             project.setIcon(customIcon);
             icon = project.getIcon();
-            validateIcon(icon, BallColor.NOTBUILT.getImage(), BallColor.NOTBUILT.getIconClassName());
+            validateSymbol(icon, BallColor.NOTBUILT.getImage(), BallColor.NOTBUILT.getIconName());
 
             customIcon = new BuildStatusFolderIcon(Set.of("doesnotexist"));
             project.setIcon(customIcon);
             icon = project.getIcon();
-            validateIcon(icon, BallColor.ABORTED.getImage(), BallColor.ABORTED.getIconClassName());
+            validateSymbol(icon, BallColor.ABORTED.getImage(), BallColor.ABORTED.getIconName());
 
             customIcon = new BuildStatusFolderIcon(Set.of("Success", "doesnotexist"));
             project.setIcon(customIcon);
             icon = project.getIcon();
-            validateIcon(icon, BallColor.BLUE.getImage(), BallColor.BLUE.getIconClassName());
+            validateSymbol(icon, BallColor.BLUE.getImage(), BallColor.BLUE.getIconName());
         }
     }
 
@@ -184,41 +184,41 @@ class BuildStatusFolderIconTest {
             mockStaplerRequest(stapler);
 
             // default
-            validateIcon(icon, BallColor.NOTBUILT.getImage(), BallColor.NOTBUILT.getIconClassName());
+            validateSymbol(icon, BallColor.NOTBUILT.getImage(), BallColor.NOTBUILT.getIconName());
 
             // Success
             FreeStyleProject success = project.createProject(FreeStyleProject.class, "Success");
             FreeStyleBuild successBuild = success.scheduleBuild2(0).get();
             r.assertBuildStatus(Result.SUCCESS, r.waitForCompletion(successBuild));
 
-            validateIcon(icon, BallColor.BLUE.getImage(), BallColor.BLUE.getIconClassName());
+            validateSymbol(icon, BallColor.BLUE.getImage(), BallColor.BLUE.getIconName());
             // Unstable
             FreeStyleProject unstable = project.createProject(FreeStyleProject.class, "Unstable");
             unstable.getBuildersList().replaceBy(Collections.singleton(new ResultBuilder(Result.UNSTABLE)));
             r.buildAndAssertStatus(Result.UNSTABLE, unstable);
 
-            validateIcon(icon, BallColor.YELLOW.getImage(), BallColor.YELLOW.getIconClassName());
+            validateSymbol(icon, BallColor.YELLOW.getImage(), BallColor.YELLOW.getIconName());
 
             // Failure
             FreeStyleProject failure = project.createProject(FreeStyleProject.class, "Failure");
             failure.getBuildersList().replaceBy(Collections.singleton(new ResultBuilder(Result.FAILURE)));
             r.buildAndAssertStatus(Result.FAILURE, failure);
 
-            validateIcon(icon, BallColor.RED.getImage(), BallColor.RED.getIconClassName());
+            validateSymbol(icon, BallColor.RED.getImage(), BallColor.RED.getIconName());
 
             // Not build
             FreeStyleProject notBuilt = project.createProject(FreeStyleProject.class, "Not Built");
             notBuilt.getBuildersList().replaceBy(Collections.singleton(new ResultBuilder(Result.NOT_BUILT)));
             r.buildAndAssertStatus(Result.NOT_BUILT, notBuilt);
 
-            validateIcon(icon, BallColor.NOTBUILT.getImage(), BallColor.NOTBUILT.getIconClassName());
+            validateSymbol(icon, BallColor.NOTBUILT.getImage(), BallColor.NOTBUILT.getIconName());
 
             // Aborted
             FreeStyleProject aborted = project.createProject(FreeStyleProject.class, "Aborted");
             aborted.getBuildersList().replaceBy(Collections.singleton(new ResultBuilder(Result.ABORTED)));
             r.buildAndAssertStatus(Result.ABORTED, aborted);
 
-            validateIcon(icon, BallColor.ABORTED.getImage(), BallColor.ABORTED.getIconClassName());
+            validateSymbol(icon, BallColor.ABORTED.getImage(), BallColor.ABORTED.getIconName());
         }
     }
 
@@ -244,7 +244,7 @@ class BuildStatusFolderIconTest {
             FreeStyleBuild successBuild = success.scheduleBuild2(0).get();
             r.assertBuildStatus(Result.SUCCESS, r.waitForCompletion(successBuild));
 
-            validateIcon(icon, BallColor.BLUE.getImage(), BallColor.BLUE.getIconClassName());
+            validateSymbol(icon, BallColor.BLUE.getImage(), BallColor.BLUE.getIconName());
 
             // Running Build
             DelayBuilder builder = new DelayBuilder();
@@ -252,7 +252,7 @@ class BuildStatusFolderIconTest {
             FreeStyleBuild runningBuild =
                     success.scheduleBuild2(0).getStartCondition().get();
 
-            validateIcon(icon, BallColor.BLUE_ANIME.getImage(), BallColor.BLUE_ANIME.getIconClassName());
+            validateSymbol(icon, BallColor.BLUE_ANIME.getImage(), BallColor.BLUE_ANIME.getIconName());
             builder.release();
 
             r.assertBuildStatus(Result.SUCCESS, r.waitForCompletion(runningBuild));
@@ -283,7 +283,7 @@ class BuildStatusFolderIconTest {
             FreeStyleBuild runningBuild =
                     running.scheduleBuild2(0).getStartCondition().get();
 
-            validateIcon(icon, BallColor.NOTBUILT_ANIME.getImage(), BallColor.NOTBUILT_ANIME.getIconClassName());
+            validateSymbol(icon, BallColor.NOTBUILT_ANIME.getImage(), BallColor.NOTBUILT_ANIME.getIconName());
             builder.release();
 
             r.assertBuildStatus(Result.SUCCESS, r.waitForCompletion(runningBuild));
@@ -313,7 +313,7 @@ class BuildStatusFolderIconTest {
 
             assertFalse(disabled.isBuildable());
             assertTrue(disabled.isDisabled());
-            validateIcon(icon, BallColor.DISABLED.getImage(), BallColor.DISABLED.getIconClassName());
+            validateSymbol(icon, BallColor.DISABLED.getImage(), BallColor.DISABLED.getIconName());
         }
     }
 
@@ -337,7 +337,7 @@ class BuildStatusFolderIconTest {
             // No Build
             project.createProject(FreeStyleProject.class, "No Build");
 
-            validateIcon(icon, BallColor.NOTBUILT.getImage(), BallColor.NOTBUILT.getIconClassName());
+            validateSymbol(icon, BallColor.NOTBUILT.getImage(), BallColor.NOTBUILT.getIconName());
         }
     }
 }

--- a/src/test/java/jenkins/plugins/foldericon/JobDSLConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/foldericon/JobDSLConfigurationTest.java
@@ -46,7 +46,7 @@ class JobDSLConfigurationTest {
     void buildStatusFolderIcon() throws Exception {
         BuildStatusFolderIcon customIcon = createFolder(r, "build-status.groovy", BuildStatusFolderIcon.class);
         assertEquals(Set.of("dev", "main"), customIcon.getJobs());
-        assertEquals(BallColor.NOTBUILT.getIconClassName(), customIcon.getIconClassName());
+        assertEquals("symbol-status-" + BallColor.NOTBUILT.getIconName(), customIcon.getIconClassName());
     }
 
     /**

--- a/src/test/java/jenkins/plugins/foldericon/utils/TestUtils.java
+++ b/src/test/java/jenkins/plugins/foldericon/utils/TestUtils.java
@@ -69,6 +69,17 @@ public final class TestUtils {
     }
 
     /**
+     * Common validation of symbols.
+     *
+     * @param icon              the icon to validate
+     * @param expectedImageName the expected image name
+     * @param expectedIconName  the expected icon name
+     */
+    public static void validateSymbol(FolderIcon icon, String expectedImageName, String expectedIconName) {
+        validateIcon(icon, expectedImageName, "symbol-status-" + expectedIconName);
+    }
+
+    /**
      * Common validation of responses.
      *
      * @param response             the response to validate


### PR DESCRIPTION
use a symbol from core instead of the icon. There is no mapping in core that translates this to the proper symbol.
With dark theme the disabled icon is currently hard to see, also the icon is not in sync with the disabled symbol from core.

Before:
![image](https://github.com/user-attachments/assets/1ff5f03b-27a8-41a0-8a04-ba0b593fdbe2)
![image](https://github.com/user-attachments/assets/8a333a5d-fbb9-4c0f-916c-5c16311bb05c)


After:
![image](https://github.com/user-attachments/assets/6b49998c-0b67-4048-93b6-ac9076dfb35c)
![image](https://github.com/user-attachments/assets/3151aa86-5491-419c-a444-43abe0cb7c2a)


<!-- Please describe your pull request here. -->

### Testing done
Interactive testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
